### PR TITLE
fix: Fix mirror mode error in screen share

### DIFF
--- a/meeting/src/assets/sass/lib/videogrid/_videogrid.scss
+++ b/meeting/src/assets/sass/lib/videogrid/_videogrid.scss
@@ -19,7 +19,14 @@
           width: calc(100% + 2px);
           height: calc(100% + 2px);
           margin: -1px;
+        }
+
+        #yourVideo {
           transform: rotateY(180deg);
+
+          &.shared {
+            transform: none;
+          }
         }
       }
       .video-info-wrap {

--- a/meeting/src/assets/ts/Elements/Controls.ts
+++ b/meeting/src/assets/ts/Elements/Controls.ts
@@ -1,170 +1,187 @@
-import { App } from "../app";
-import { Cookie } from "../Utils/Cookie";
-import { Translator } from "../Utils/Translator";
-import { Alert } from "./Alert";
+import { App } from '../app';
+import { Cookie } from '../Utils/Cookie';
+import { Translator } from '../Utils/Translator';
+import { Alert } from './Alert';
 
 declare var Vue: any;
 
-export class Controls{
+export class Controls {
+  app: App;
+  controlsVueObject: any;
 
-    app: App;
-    controlsVueObject: any; 
+  readonly microphoneCookie: string = 'microphoneOn';
+  readonly cameraCookie: string = 'cameraOn';
 
-    readonly microphoneCookie: string = 'microphoneOn';
-    readonly cameraCookie: string = 'cameraOn';
+  constructor(app: App) {
+    this.app = app;
+    this.initialElements();
+    this.setSidebarClickRemove();
+  }
 
-    constructor(app: App){
-        this.app = app;
-        this.initialElements();
-        this.setSidebarClickRemove();
+  initialElements() {
+    let cla = this;
+    this.controlsVueObject = new Vue({
+      el: '#controls',
+      data: {
+        microphoneOn:
+          Cookie.getCookie(cla.microphoneCookie) == 'false' ? false : true,
+        cameraOn: Cookie.getCookie(cla.cameraCookie) == 'false' ? false : true,
+        hangouted: false,
+        screenOn: false,
+        optionOn: false,
+        screenSharingNotAllowed:
+          /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+            navigator.userAgent
+          ),
+        hasNewMessage: false,
+      },
+      methods: {
+        toogleMicrophone: function () {
+          if (cla.app.localStream !== undefined) {
+            this.microphoneOn = !this.microphoneOn;
+            Cookie.setCookie(cla.microphoneCookie, this.microphoneOn);
+            cla.toogleStreamMicrophone(false);
+            cla.app.sendMessageToAllPartners(cla.app.userinfo.getUserInfo());
+          } else {
+            new Alert(Translator.get('cannotstartmicrophone'));
+          }
+        },
+        toogleCamera: function () {
+          if (
+            !cla.app.microphoneOnlyNotChangeable &&
+            cla.app.localStream !== undefined
+          ) {
+            this.cameraOn = !this.cameraOn;
+            cla.app.microphoneOnly = !this.cameraOn;
+            Cookie.setCookie(cla.cameraCookie, this.cameraOn);
+            cla.toogleStreamCamera();
+            cla.app.sendMessageToAllPartners(cla.app.userinfo.getUserInfo());
+          } else {
+            new Alert(Translator.get('cannotstartcamera'));
+          }
+          cla.app.toggleCameraInApp(this.cameraOn);
+        },
+        hangOut: function () {
+          if (!this.hangouted) {
+            cla.hangOut();
+            this.hangouted = true;
+          } else {
+            location.hash = cla.app.room;
+            location.reload();
+          }
+        },
+        toogleScreen: function () {
+          if (cla.app.screen.onScreenMode()) {
+            $('#yourVideo').removeClass('shared');
+            cla.app.screen.stopScreen();
+          } else {
+            $('#yourVideo').addClass('shared');
+            cla.app.screen.startScreen();
+          }
+        },
+        toogleOption: function () {
+          this.optionOn = !this.optionOn;
+          cla.toogleOption();
+        },
+      },
+    });
+
+    this.setMutedIcon();
+    this.setCameraOffIcon();
+
+    //tabs
+    $('#sidebar .tabs .tabs-header > *:first').addClass('active');
+    $('#sidebar .tabs .tabs-content > *:first').addClass('active');
+
+    $('#sidebar .tabs .tabs-header > *').on('click', function () {
+      var t = $(this).attr('tab');
+      cla.activateSidebarTab(t);
+    });
+  }
+
+  activateSidebarTab(type: string) {
+    $('#sidebar .tabs .tabs-header > *').removeClass('active');
+    $('#sidebar .tabs .tabs-header > [tab=' + type + '] ').addClass('active');
+
+    $('#sidebar .tabs .tabs-content > *').removeClass('active');
+    $('#sidebar .tabs .tabs-content > #tab-' + type).addClass('active');
+  }
+
+  initialiseStream() {
+    this.toogleStreamMicrophone(false);
+    this.toogleStreamCamera(false);
+  }
+
+  toogleStreamMicrophone(changeCamera: boolean = true) {
+    if (this.app.localStream == undefined) {
+      this.controlsVueObject.microphoneOn = false;
+    } else {
+      this.app.localStream.getAudioTracks()[0].enabled =
+        this.controlsVueObject.microphoneOn;
+      if (changeCamera && this.controlsVueObject.microphoneOn) {
+        this.app.initialCamera();
+      }
     }
+    this.setMutedIcon();
+  }
 
-    initialElements(){
-        let cla = this;
-        this.controlsVueObject = new Vue({
-            el: '#controls',
-            data: {
-                microphoneOn: Cookie.getCookie(cla.microphoneCookie) == 'false' ? false : true,
-                cameraOn: Cookie.getCookie(cla.cameraCookie) == 'false' ? false : true,
-                hangouted: false,
-                screenOn: false,
-                optionOn: false,
-                screenSharingNotAllowed: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent),
-                hasNewMessage: false
-            },
-            methods: {
-                toogleMicrophone: function () {
-                    if(cla.app.localStream !== undefined){
-                    this.microphoneOn = !this.microphoneOn;
-                    Cookie.setCookie(cla.microphoneCookie, this.microphoneOn);
-                    cla.toogleStreamMicrophone(false);
-                    cla.app.sendMessageToAllPartners(cla.app.userinfo.getUserInfo());
-                    } else {
-                        new Alert(Translator.get("cannotstartmicrophone"));
-                    }
-                },
-                toogleCamera: function () {
-                    if(!cla.app.microphoneOnlyNotChangeable && cla.app.localStream !== undefined){
-                        this.cameraOn = !this.cameraOn;
-                        cla.app.microphoneOnly = !this.cameraOn;
-                        Cookie.setCookie(cla.cameraCookie, this.cameraOn);
-                        cla.toogleStreamCamera();
-                        cla.app.sendMessageToAllPartners(cla.app.userinfo.getUserInfo());
-                    } else {
-                        new Alert(Translator.get("cannotstartcamera"));
-                    }
-                    cla.app.toggleCameraInApp(this.cameraOn);
-                },hangOut: function () {
-                    if(!this.hangouted){
-                        cla.hangOut();
-                        this.hangouted = true;
-                    } else{
-                        location.hash = cla.app.room;
-                        location.reload();
-                    }                    
-                }, toogleScreen: function(){
-                    if(cla.app.screen.onScreenMode()){
-                        cla.app.screen.stopScreen();
-                    }else{
-                        cla.app.screen.startScreen();
-                    }
-                }, toogleOption: function(){
-                    this.optionOn = !this.optionOn;
-                    cla.toogleOption(); 
-                }
-            }
-        });
-
-        this.setMutedIcon();
-        this.setCameraOffIcon();
-
-
-        //tabs
-        $('#sidebar .tabs .tabs-header > *:first').addClass('active');
-        $('#sidebar .tabs .tabs-content > *:first').addClass('active');
-            
-        $('#sidebar .tabs .tabs-header > *').on('click', function(){
-            var t = $(this).attr('tab');
-            cla.activateSidebarTab(t);
-        });
-
+  toogleStreamCamera(changeCamera: boolean = true) {
+    if (
+      this.app.microphoneOnlyNotChangeable ||
+      this.app.localStream == undefined
+    ) {
+      this.controlsVueObject.cameraOn = false;
+    } else {
+      if (this.app.localStream.getVideoTracks()[0] != undefined) {
+        this.app.localStream.getVideoTracks()[0].enabled =
+          this.controlsVueObject.cameraOn;
+      }
+      if (changeCamera) {
+        this.app.initialCamera();
+      }
     }
+    this.setCameraOffIcon();
+  }
 
-    activateSidebarTab(type: string){
-        $('#sidebar .tabs .tabs-header > *').removeClass('active');           
-        $('#sidebar .tabs .tabs-header > [tab=' + type + '] ').addClass('active');
+  setMutedIcon() {
+    this.app.yourVideoElement.videoVueObject.muted =
+      !this.controlsVueObject.microphoneOn;
+    this.app.partnerListElement.partnerListElementVueObject.muted =
+      !this.controlsVueObject.microphoneOn;
+  }
 
-        $('#sidebar .tabs .tabs-content > *').removeClass('active');  
-        $('#sidebar .tabs .tabs-content > #tab-'+ type ).addClass('active');
+  setCameraOffIcon() {
+    this.app.yourVideoElement.videoVueObject.cameraOff =
+      !this.controlsVueObject.cameraOn;
+    this.app.partnerListElement.partnerListElementVueObject.cameraOff =
+      !this.controlsVueObject.cameraOn;
+  }
+
+  toogleOption() {
+    this.app.sidebarToogle(this.controlsVueObject.optionOn);
+  }
+
+  setSidebarClickRemove() {
+    var cla = this;
+    $('#clickbackground').on('click', function () {
+      if (cla.controlsVueObject.optionOn) {
+        cla.controlsVueObject.toogleOption();
+      }
+    });
+  }
+
+  hangOut() {
+    this.app.hangOut();
+  }
+
+  setNewMessage(hasNewMessage) {
+    this.controlsVueObject.hasNewMessage = hasNewMessage;
+    if (hasNewMessage) {
+      $('#sidebar .tabs .tabs-header > [tab=chat] ').addClass('notification');
+    } else {
+      $('#sidebar .tabs .tabs-header > [tab=chat] ').removeClass(
+        'notification'
+      );
     }
-
-    initialiseStream(){
-        this.toogleStreamMicrophone(false);
-        this.toogleStreamCamera(false); 
-    }
-
-    toogleStreamMicrophone(changeCamera: boolean = true)
-    {
-        if(this.app.localStream == undefined){
-            this.controlsVueObject.microphoneOn = false;  
-        }else {
-            this.app.localStream.getAudioTracks()[0].enabled = this.controlsVueObject.microphoneOn;
-            if(changeCamera && this.controlsVueObject.microphoneOn){
-                this.app.initialCamera();  
-            }
-        }
-        this.setMutedIcon();
-    }
-
-    toogleStreamCamera(changeCamera: boolean = true)
-    {
-        if(this.app.microphoneOnlyNotChangeable || this.app.localStream == undefined){
-            this.controlsVueObject.cameraOn = false;  
-        } else {
-            if(this.app.localStream.getVideoTracks()[0] != undefined){
-                this.app.localStream.getVideoTracks()[0].enabled = this.controlsVueObject.cameraOn;
-            }
-            if(changeCamera){
-                this.app.initialCamera();
-            }
-        }
-        this.setCameraOffIcon();
-    }
-
-    setMutedIcon(){
-        this.app.yourVideoElement.videoVueObject.muted = !this.controlsVueObject.microphoneOn;
-        this.app.partnerListElement.partnerListElementVueObject.muted = !this.controlsVueObject.microphoneOn;
-    }
-
-    setCameraOffIcon(){
-        this.app.yourVideoElement.videoVueObject.cameraOff = !this.controlsVueObject.cameraOn;
-        this.app.partnerListElement.partnerListElementVueObject.cameraOff = !this.controlsVueObject.cameraOn;
-    }
-
-    toogleOption(){
-        this.app.sidebarToogle(this.controlsVueObject.optionOn);
-    }
-
-    setSidebarClickRemove(){
-        var cla = this;
-        $("#clickbackground").on("click", function(){
-            if(cla.controlsVueObject.optionOn){
-                cla.controlsVueObject.toogleOption();
-            }
-        });
-    }
-
-    hangOut(){
-        this.app.hangOut();
-    }
-
-    setNewMessage(hasNewMessage){
-        this.controlsVueObject.hasNewMessage = hasNewMessage; 
-        if(hasNewMessage){
-            $('#sidebar .tabs .tabs-header > [tab=chat] ').addClass('notification');
-        }else{
-            $('#sidebar .tabs .tabs-header > [tab=chat] ').removeClass('notification');
-        }
-    }
-
+  }
 }


### PR DESCRIPTION
## 💻 작업 내용

- 이전까지는 송출되는 모든 video 태그가 180도 회전된 상태였다. 
- 상대방에게 송출되는 내 video는 미러모드를 적용하지 않는다. 
- 현재 내 화면이 screen share를 하고 있다면 미러모드를 해제한다. 
- screen share를 종료하면 다시 미러모드를 적용한다. 

## 📸 스크린샷

![image](https://user-images.githubusercontent.com/52737532/139650714-8f852c0e-564a-4be2-961c-e177aa7e7451.png)

- 화면을 공유중이면 내 video에서 미러모드가 적용되지 않는다. 
 
![image](https://user-images.githubusercontent.com/52737532/139650895-0d1f8527-1af3-4623-9aff-20bb13bb3877.png)

- 상대방에게도 미러모드가 적용되지 않은 화면이 보여진다. 

![image](https://user-images.githubusercontent.com/52737532/139650986-1c9dd33b-5c5c-45e6-ada7-83cf8ddb33a3.png)

- 화면 공유가 종료되면 다시 미러모드가 적용된다. 

## 👄 덧붙임 말


