### PR TITLE
Move lip magnifying function into app

### DIFF
--- a/meeting/src/assets/ts/Elements/Hotkey.ts
+++ b/meeting/src/assets/ts/Elements/Hotkey.ts
@@ -129,6 +129,8 @@ export class Hotkey {
           }
 
           app.switch_.switchVueObject.toggleLibMagnify();
+          app.featureOnOffVueObject.isLipMagnify();
+
           return false;
         }
 

--- a/meeting/src/assets/ts/app.ts
+++ b/meeting/src/assets/ts/app.ts
@@ -492,7 +492,15 @@ export class App {
           }
         },
 
-        isLipMagnify: function () {},
+        isLipMagnify: function () {
+          var lips_area = document.getElementById('lips-area');
+
+          if ($(document.getElementById('libMagnify')).prop('checked')) {
+            lips_area.style.display = 'inline';
+          } else {
+            lips_area.style.display = 'none';
+          }
+        },
       },
     });
   }

--- a/meeting/src/index.html
+++ b/meeting/src/index.html
@@ -47,15 +47,6 @@
         minTrackingConfidence: 0.5,
       });
       var interval = null;
-      function check(input) {
-        var lips_area = document.getElementById('lips-area');
-
-        if (input.checked == true) {
-          lips_area.style.display = 'inline';
-        } else {
-          lips_area.style.display = 'none';
-        }
-      }
 
       function libSelect() {
         var delay = 0;
@@ -472,8 +463,7 @@
                       <input
                         type="checkbox"
                         id="libMagnify"
-                        onclick="check(this)"
-                        v-on:click="isLipMagnify"
+                        v-on:click="isLipMagnify()"
                       />
                       <span class="slider round"></span>
                     </label>


### PR DESCRIPTION
## 💻 작업 내용

- 단축키로 입 확대 기능을 켜고 끌 수 있게 기존에 `index.html`에 존재했던 입 확대 함수를 `app.ts`로 이동시켰습니다. 

## 📸 스크린샷


## 👄 덧붙임 말

